### PR TITLE
Fix newline encoding problem on Linux hosts

### DIFF
--- a/PyTac_verif.py
+++ b/PyTac_verif.py
@@ -45,7 +45,7 @@ def parse_certificate(data):
     return
   else:
     msg = bin_data[:sign_offset]  
-    signature = bin_data[sign_offset+1:]
+    signature = bin_data.strip()[sign_offset+1:]
     signature = signature + (8-len(signature)%8)*b'=' #base32 padding
     bsign = b32decode(signature)
     return msg, bsign


### PR DESCRIPTION
Opening and saving the attached .txt file on Linux and running the script again results in a "binascii.Error: Non-base32 digit found" error. Removing all newlines with the strip() function seems to solve the problem both for original files and linux-edited files